### PR TITLE
Add OpenAPI 3.1 API key fixture coverage

### DIFF
--- a/examples/xquik-openapi-3-1.json
+++ b/examples/xquik-openapi-3-1.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Xquik API",
+    "version": "1.0.0",
+    "description": "Minimal OpenAPI 3.1 fixture for API key auth."
+  },
+  "servers": [
+    {
+      "url": "https://xquik.com"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "paths": {
+    "/api/v1/x/tweets/search": {
+      "get": {
+        "operationId": "searchTweets",
+        "summary": "Search Tweets",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tweet search results"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      }
+    }
+  }
+}

--- a/tests/openapi-3-1-api-key.test.ts
+++ b/tests/openapi-3-1-api-key.test.ts
@@ -1,0 +1,18 @@
+import SwaggerParser from '@apidevtools/swagger-parser';
+import path from 'path';
+
+describe('OpenAPI 3.1 API key fixtures', () => {
+  it('parses the Xquik fixture with header API key auth', async () => {
+    const fixturePath = path.join(process.cwd(), 'examples', 'xquik-openapi-3-1.json');
+    const spec = await SwaggerParser.parse(fixturePath) as any;
+
+    expect(spec.openapi).toBe('3.1.0');
+    expect(spec.info.title).toBe('Xquik API');
+    expect(spec.paths['/api/v1/x/tweets/search'].get.operationId).toBe('searchTweets');
+    expect(spec.components.securitySchemes.apiKey).toMatchObject({
+      type: 'apiKey',
+      in: 'header',
+      name: 'x-api-key',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a minimal OpenAPI 3.1 fixture for the public Xquik tweet search endpoint.
- Adds a Jest parser test that verifies header API key metadata is preserved.

## Validation

- Jest test suite passed in-band
- TypeScript build passed
